### PR TITLE
correct a mistake with mixing up 'left' and 'right' child nodes

### DIFF
--- a/_sources/Trees/SearchTreeImplementation.rst
+++ b/_sources/Trees/SearchTreeImplementation.rst
@@ -413,9 +413,9 @@ left child. The decision proceeds as follows:
    to point to the current node’s left child.
 
 #. If the current node is a right child then we only need to update the
-   parent reference of the right child to point to the parent of the
+   parent reference of the left child to point to the parent of the
    current node, and then update the right child reference of the parent
-   to point to the current node’s right child.
+   to point to the current node’s left child.
 
 #. If the current node has no parent, it must be the root. In this case
    we will just replace the ``key``, ``payload``, ``leftChild``, and


### PR DESCRIPTION
The book has a description for next piece of code from `Listing 9`:
```
       if currentNode.hasLeftChild():
    	  if currentNode.isLeftChild():
    	      currentNode.leftChild.parent = currentNode.parent
    	      currentNode.parent.leftChild = currentNode.leftChild
    	  elif currentNode.isRightChild():
    	      currentNode.leftChild.parent = currentNode.parent
    	      currentNode.parent.rightChild = currentNode.leftChild
    	  else:
    	      currentNode.replaceNodeData(currentNode.leftChild.key,
    				 currentNode.leftChild.payload,
    				 currentNode.leftChild.leftChild,
    				 currentNode.leftChild.rightChild)
```

The purpose of this pull request is to fix a description for the case, when `currentNode.isRightChild()`