### PR TITLE
changed href for assignments link to point to dynamic assignment page

### DIFF
--- a/_sources/index.rst
+++ b/_sources/index.rst
@@ -21,7 +21,7 @@ By Brad Miller and David Ranum, Luther College
 .. raw:: html
 
    <ul>
-   <li><a href="assignments.html">Assignments</a></li>
+   <li><a href="../../assignments/chooseAssignment.html">Assignments</a></li>
    </ul>
 
 .. toctree::


### PR DESCRIPTION
This shouldn't be merged until the dynamic assignment pages are finished and merged.