### PR TITLE
Fix deque docstring and combine duplicate exercises.

### DIFF
--- a/_sources/BasicDS/Exercises.rst
+++ b/_sources/BasicDS/Exercises.rst
@@ -30,7 +30,7 @@ Programming Exercises
    dequeue have :math:`O(1)` performance *on average*. In this case it
    means that most of the time enqueue and dequeue will be
    :math:`O(1)` except in one particular circumstance where dequeue
-   will be :math:`O(n)`.
+   will be :math:`O(n)`. Create an implementation of a queue that would have an average performance of :math:`O(1)` for enqueue and dequeue operations.
 
 #. Consider a real life situation. Formulate a question and then design
    a simulation that can help to answer it. Possible situations include:
@@ -144,6 +144,3 @@ Programming Exercises
    node (commonly called back). The head reference also contains two
    references, one to the first node in the linked list and one to the
    last. Code this implementation in Python.
-
-#. Create an implementation of a queue that would have an average performance of
-   O(1) for enqueue and dequeue operations.

--- a/_sources/BasicDS/ImplementingaDequeinPython.rst
+++ b/_sources/BasicDS/ImplementingaDequeinPython.rst
@@ -21,7 +21,7 @@ the rear of the deque is at position 0 in the list.
 ::
 
     class Deque:
-        """Queue implementation as a list"""
+        """Deque implementation as a list"""
 
         def __init__(self):
             """Create new deque"""


### PR DESCRIPTION
This PR:

* Fixes the `Deque` docstring to refer to a deque, not a queue.
* Combines exercises 7 and 28 from the basic DS exercises section.