### PR TITLE
Fixed f-string formatting table 11

### DIFF
--- a/_sources/Introduction/InputandOutput.rst
+++ b/_sources/Introduction/InputandOutput.rst
@@ -233,7 +233,7 @@ method for the rest of the text.
                        number      ``:20d``                                                               Put the value in a field width of 20
                         ``<``     ``:<20d``                                          Put the value in a field 20 characters wide, left-aligned
                         ``>``     ``:>20d``                                         Put the value in a field 20 characters wide, right-aligned
-                        ``^``     ``:^20d``                                         Put the value in a field 20 characters wide, right-aligned
+                        ``^``     ``:^20d``                                        Put the value in a field 20 characters wide, center-aligned
                         ``0``     ``:020d``                           Put the value in a field 20 characters wide, fill in with leading zeros.
                         ``.``    ``:20.2f``   Put the value in a field 20 characters wide with 2 characters to the right of the decimal point.
     ========================= ============= ==================================================================================================


### PR DESCRIPTION
The center alignment modifier for f-strings was incorrectly labeled as the right alignment modifier.