### PR TITLE
Fixed typo in activity 1.13.2.1

### DIFF
--- a/_sources/Introduction/ObjectOrientedProgramminginPythonDefiningClasses.rst
+++ b/_sources/Introduction/ObjectOrientedProgramminginPythonDefiningClasses.rst
@@ -953,7 +953,7 @@ Try it yourself using ActiveCode 4.
 
     class NotGate(UnaryGate):
 
-        def __init__(self, nlbl):
+        def __init__(self, lbl):
             UnaryGate.__init__(self, lbl)
 
         def perform_gate_logic(self):


### PR DESCRIPTION
Variable name had an extra letter which caused a NameError when run in the browser.